### PR TITLE
[jabas/elastic] Set the default port to 40000, the same as the port for run_scheduler.py

### DIFF
--- a/jabas/elastic/launch.py
+++ b/jabas/elastic/launch.py
@@ -50,8 +50,10 @@ if __name__=='__main__':
 
     parser.add_argument('--log_dir', type=str, default=None,
                         help='Directory where log is stored')
-    parser.add_argument('-s', '--sched_port', type=int, default=50060,
-                        help='Port number for scheduler server')
+    parser.add_argument('-s', '--sched_port', type=int, default=40000,
+                        help='Port number for scheduler server. '
+                             'CAUTION: This must be the same port as the command: '
+                             'jabas/elastic/run_scheduler.py --port 40000')
     parser.add_argument('-w', '--worker_port', type=int, default=50061,
                         help='Port number for worker server')
 


### PR DESCRIPTION
The default port has been changed, as it must match run_scheduler.py for the server-client connection to work.